### PR TITLE
Add support for environment variables

### DIFF
--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/DataTypes.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/DataTypes.scala
@@ -26,6 +26,8 @@ object DataTypes {
     def apply(key: String, value: String): DockerComposeOption = apply(key, Some(value))
   }
 
+  case class EnvironmentVariable(key: String, value: String)
+
   sealed trait DockerComposeError {
     def msg: String
   }

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/Command.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/Command.scala
@@ -1,7 +1,6 @@
 package com.github.ehsanyou.sbt.docker.compose.commands
 
-import com.github.ehsanyou.sbt.docker.compose.DataTypes.DockerComposeOption
-import com.github.ehsanyou.sbt.docker.compose.DataTypes.DockerComposeOptionKey
+import com.github.ehsanyou.sbt.docker.compose.DataTypes.{DockerComposeOption, DockerComposeOptionKey, EnvironmentVariable}
 
 trait Command {
 
@@ -10,6 +9,8 @@ trait Command {
   def name: String
 
   def build: String
+
+  def environment: Seq[(String, String)]
 
   def isEmpty: Boolean
 
@@ -27,12 +28,15 @@ trait Command {
 
   def withServices(services: Seq[String]): CommandType = appendServices(services.map(DockerComposeOption.apply))
 
+  def withEnvVar(envVar: (String, String)): CommandType = appendEnvVar(EnvironmentVariable(envVar._1, envVar._2))
+
   def appendOption(option: DockerComposeOption): CommandType
 
   def removeOption(optionKeys: String*): CommandType
 
   def appendServices(services: Seq[DockerComposeOption]): CommandType
 
+  def appendEnvVar(envVar: EnvironmentVariable): CommandType
 }
 
 object Command {

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/dc/DockerComposeCmd.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/dc/DockerComposeCmd.scala
@@ -1,6 +1,6 @@
 package com.github.ehsanyou.sbt.docker.compose.commands.dc
 
-import com.github.ehsanyou.sbt.docker.compose.DataTypes.DockerComposeOption
+import com.github.ehsanyou.sbt.docker.compose.DataTypes.{DockerComposeOption, EnvironmentVariable}
 import com.github.ehsanyou.sbt.docker.compose.commands.Command
 
 case class DockerComposeCmd(underlying: DockerCompose = DockerCompose()) extends Command {
@@ -11,6 +11,7 @@ case class DockerComposeCmd(underlying: DockerCompose = DockerCompose()) extends
   override val isEmpty: Boolean = underlying.options.isEmpty
   override def build: String =
     Command.asString(name, underlying.options)(DockerCompose.nonNativeOptions.flatMap(_.keys): _*)
+  override def environment: Seq[(String, String)] = Seq.empty
   override def hasEmptyOption: Boolean = underlying.options.isEmpty
 
   private[compose] def withComposeFiles(
@@ -39,4 +40,6 @@ case class DockerComposeCmd(underlying: DockerCompose = DockerCompose()) extends
     }
 
   override def appendServices(services: Seq[DockerComposeOption]): DockerComposeCmd = this
+
+  override def appendEnvVar(envVar: EnvironmentVariable): CommandType = this
 }

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/down/DockerComposeDownCmd.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/down/DockerComposeDownCmd.scala
@@ -1,6 +1,6 @@
 package com.github.ehsanyou.sbt.docker.compose.commands.down
 
-import com.github.ehsanyou.sbt.docker.compose.DataTypes.DockerComposeOption
+import com.github.ehsanyou.sbt.docker.compose.DataTypes.{DockerComposeOption, EnvironmentVariable}
 import com.github.ehsanyou.sbt.docker.compose.commands.Command
 
 case class DockerComposeDownCmd(underlying: DockerComposeDown = DockerComposeDown()) extends Command {
@@ -11,6 +11,8 @@ case class DockerComposeDownCmd(underlying: DockerComposeDown = DockerComposeDow
   override val isEmpty: Boolean = underlying.options.isEmpty
 
   override def build: String = Command.asString(name, underlying.options, underlying.services)()
+
+  override def environment: Seq[(String, String)] = Seq.empty
 
   override def hasEmptyOption: Boolean = underlying.options.isEmpty && underlying.services.isEmpty
 
@@ -23,4 +25,6 @@ case class DockerComposeDownCmd(underlying: DockerComposeDown = DockerComposeDow
 
   override def appendServices(services: Seq[DockerComposeOption]): DockerComposeDownCmd =
     copy(underlying.copy(services = underlying.services ++ services))
+
+  override def appendEnvVar(envVar: EnvironmentVariable): CommandType = this
 }

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/test/DockerComposeTest.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/test/DockerComposeTest.scala
@@ -9,12 +9,13 @@ case class DockerComposeTest(
   options: Seq[DockerComposeOption],
   services: Seq[DockerComposeOption],
   tags: Seq[(String, String)],
-  testType: TestType
+  testType: TestType,
+  envVars: Seq[EnvironmentVariable]
 )
 
 object DockerComposeTest extends CommandCompanion {
 
-  def apply(testType: TestType): DockerComposeTest = DockerComposeTest(Seq.empty, Seq.empty, Seq.empty, testType)
+  def apply(testType: TestType): DockerComposeTest = DockerComposeTest(Seq.empty, Seq.empty, Seq.empty, testType, Seq.empty)
 
   override val options: Seq[DockerComposeOptionKey] = DockerComposeUp.options
 

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/test/DockerComposeTestCmd.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/test/DockerComposeTestCmd.scala
@@ -1,6 +1,6 @@
 package com.github.ehsanyou.sbt.docker.compose.commands.test
 
-import com.github.ehsanyou.sbt.docker.compose.DataTypes.DockerComposeOption
+import com.github.ehsanyou.sbt.docker.compose.DataTypes.{DockerComposeOption, EnvironmentVariable}
 import com.github.ehsanyou.sbt.docker.compose.commands.Command
 import com.github.ehsanyou.sbt.docker.compose.commands.test.DockerComposeTest._
 
@@ -12,6 +12,8 @@ case class DockerComposeTestCmd(underlying: DockerComposeTest) extends Command {
   override val isEmpty: Boolean = underlying.options.isEmpty && underlying.services.isEmpty && underlying.tags.isEmpty
 
   override def build: String = Command.asString(name, underlying.options, underlying.services)()
+
+  override def environment: Seq[(String, String)] = underlying.envVars.map(e => (e.key, e.value))
 
   override def hasEmptyOption: Boolean = underlying.options.isEmpty
 
@@ -31,6 +33,9 @@ case class DockerComposeTestCmd(underlying: DockerComposeTest) extends Command {
 
   override def appendServices(services: Seq[DockerComposeOption]): DockerComposeTestCmd =
     copy(underlying.copy(services = underlying.services ++ services))
+
+  override def appendEnvVar(envVar: EnvironmentVariable): DockerComposeTestCmd =
+    copy(underlying.copy(envVars = underlying.envVars :+ envVar))
 }
 
 object DockerComposeTestCmd {

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/up/DockerComposeUp.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/up/DockerComposeUp.scala
@@ -6,7 +6,8 @@ import com.github.ehsanyou.sbt.docker.compose.commands.CommandCompanion
 case class DockerComposeUp(
   options: Seq[DockerComposeOption],
   services: Seq[DockerComposeOption],
-  tags: Seq[(String, String)]
+  tags: Seq[(String, String)],
+  envVars: Seq[EnvironmentVariable]
 )
 
 object DockerComposeUp extends CommandCompanion {
@@ -28,7 +29,7 @@ object DockerComposeUp extends CommandCompanion {
       ap("--timeout", keyOnly = false) ::
       Nil
 
-  def apply(): DockerComposeUp = DockerComposeUp(Seq.empty, Seq.empty, Seq.empty)
+  def apply(): DockerComposeUp = DockerComposeUp(Seq.empty, Seq.empty, Seq.empty, Seq.empty)
 
   implicit def asCommand(dockerComposeUp: DockerComposeUp): DockerComposeUpCmd =
     DockerComposeUpCmd(dockerComposeUp)

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/up/DockerComposeUpCmd.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/commands/up/DockerComposeUpCmd.scala
@@ -1,6 +1,6 @@
 package com.github.ehsanyou.sbt.docker.compose.commands.up
 
-import com.github.ehsanyou.sbt.docker.compose.DataTypes.DockerComposeOption
+import com.github.ehsanyou.sbt.docker.compose.DataTypes.{DockerComposeOption, EnvironmentVariable}
 import com.github.ehsanyou.sbt.docker.compose.commands.Command
 
 case class DockerComposeUpCmd(underlying: DockerComposeUp = DockerComposeUp()) extends Command {
@@ -12,6 +12,8 @@ case class DockerComposeUpCmd(underlying: DockerComposeUp = DockerComposeUp()) e
 
   override def build: String = Command.asString(name, underlying.options, underlying.services)()
 
+  override def environment: Seq[(String, String)] = underlying.envVars.map(e => (e.key, e.value))
+
   override def hasEmptyOption: Boolean = underlying.options.isEmpty
 
   override def appendOption(option: DockerComposeOption): DockerComposeUpCmd =
@@ -22,4 +24,6 @@ case class DockerComposeUpCmd(underlying: DockerComposeUp = DockerComposeUp()) e
   }
   override def appendServices(services: Seq[DockerComposeOption]): DockerComposeUpCmd =
     copy(underlying.copy(services = underlying.services ++ services))
+  override def appendEnvVar(envVar: EnvironmentVariable): DockerComposeUpCmd =
+    copy(underlying.copy(envVars = underlying.envVars :+ envVar))
 }

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/helpers/package.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/helpers/package.scala
@@ -28,11 +28,13 @@ package object helpers {
   def process[T](
     command: String
   )(
+    environment: Seq[(String, String)]
+  )(
     onSuccess: => T
   )(
     implicit cwd: Cwd
   ): T = {
-    if (Process(command, cwd.dir).! == 0) onSuccess
+    if (Process(command, cwd.dir, environment: _*).! == 0) onSuccess
     else throw new InvalidExitCodeException(s"`$command` command returned non-zero exit code.")
   }
 

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/parsers/package.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/parsers/package.scala
@@ -71,7 +71,8 @@ package object parsers extends ParserHelper {
             testType = testType,
             options = options.getOrElse(Seq.empty),
             tags = tags.getOrElse(Seq.empty),
-            services = parsedServices.getOrElse(Seq.empty)
+            services = parsedServices.getOrElse(Seq.empty),
+            envVars = Seq.empty
           )
         )
     }
@@ -97,7 +98,8 @@ package object parsers extends ParserHelper {
         DockerComposeUp(
           options = options.getOrElse(Seq.empty),
           tags = tags.getOrElse(Seq.empty),
-          services = parsedServices.getOrElse(Seq.empty)
+          services = parsedServices.getOrElse(Seq.empty),
+          envVars = Seq.empty
         )
     }
 

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/runner/DockerComposeDownRunner.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/runner/DockerComposeDownRunner.scala
@@ -19,7 +19,7 @@ class DockerComposeDownRunner(
 ) extends Runner {
 
   override def run: Future[Def.Initialize[Task[Unit]]] =
-    process(command)(sbtFutureTask.empty)
+    process(command)(preConfiguredDockerComposeDownCmd.environment)(sbtFutureTask.empty)
 
   private val command: String =
     if (dockerComposeDownCmd.hasEmptyOption) {

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/runner/DockerComposeTestRunner.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/runner/DockerComposeTestRunner.scala
@@ -44,7 +44,7 @@ class DockerComposeTestRunner(
 ) extends Runner {
 
   override def run: Future[Def.Initialize[Task[Unit]]] =
-    process(command) {
+    process(command)(preConfiguredDockerComposeTestCmd.environment) {
 
       if (consoleLoggerEnabled) processNonBlocking(s"docker-compose $projectName logs -f --tail=all")
 
@@ -130,7 +130,7 @@ class DockerComposeTestRunner(
   private def dockerComposeDown =
     process(
       s"docker-compose $projectName -f $dockerComposeFilePath down --remove-orphans"
-    )(())
+    )(Seq.empty)(())
 
   private val command: String = {
 

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/runner/DockerComposeUpRunner.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/runner/DockerComposeUpRunner.scala
@@ -22,7 +22,7 @@ class DockerComposeUpRunner(
 ) extends Runner {
 
   override def run: Future[Def.Initialize[Task[Unit]]] =
-    process(command)(sbtFutureTask.empty)
+    process(command)(preConfiguredDockerComposeUpCmd.environment)(sbtFutureTask.empty)
 
   lazy val dockerComposeCmdWithTagSubstitution = TagSubstitutor(
     dockerComposeCmd.withProjectName(projectName),


### PR DESCRIPTION
This PR adds environment variable support to the `test` and `up` commands.

Environment variables then can be used as substitutions in the `docker-compose.yml` file: https://docs.docker.com/compose/compose-file/#variable-substitution