### PR TITLE
Support Docker Compose override files

### DIFF
--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/DockerCompose.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/DockerCompose.scala
@@ -111,7 +111,7 @@ object DockerCompose extends AutoPlugin {
   }
 
   lazy val dockerComposeOverridesPatternImpl: Def.Initialize[PathFinder] = Def.setting {
-    baseDirectory.value * "docker-compose.overrides.yml"
+    baseDirectory.value * "docker-compose.override.yml"
   }
 
   lazy val dockerComposeTestDummyImpl: Def.Initialize[Task[Unit]] = Def.task(())

--- a/src/main/scala/com/github/ehsanyou/sbt/docker/compose/Keys.scala
+++ b/src/main/scala/com/github/ehsanyou/sbt/docker/compose/Keys.scala
@@ -28,6 +28,8 @@ object Keys {
 
   val dockerComposeFilePath = settingKey[String]("docker-compose file path")
 
+  val dockerComposeOverridesPattern = settingKey[PathFinder]("file pattern for additional docker-compose.override.yml files.")
+
   val dockerComposeIgnore = settingKey[Boolean](
     "Ignores all provided tasks in project scope -- useful for root projects in multi-project configuration"
   )


### PR DESCRIPTION
Adds as new setting key to configure path finders that can obtain a list of Docker Compose files in addition to the default `docker-compose.yml` file.

The default value is `docker-compose.override.yml` in the root project folder but, since it uses a `PathFinder`, more complex folder scans can be configured.